### PR TITLE
Add zodiac util and path alias

### DIFF
--- a/packages/astro-data/lib/index.ts
+++ b/packages/astro-data/lib/index.ts
@@ -7,3 +7,23 @@ export function getLifePathNumber(birth: string) {
   }
   return sum;
 }
+
+export function getZodiacSign(birth: string): string {
+  const [, monthStr, dayStr] = birth.split('-');
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const value = month * 100 + day;
+
+  if (value >= 120 && value <= 218) return 'Aquarius';
+  if (value >= 219 && value <= 320) return 'Pisces';
+  if (value >= 321 && value <= 419) return 'Aries';
+  if (value >= 420 && value <= 520) return 'Taurus';
+  if (value >= 521 && value <= 621) return 'Gemini';
+  if (value >= 622 && value <= 722) return 'Cancer';
+  if (value >= 723 && value <= 822) return 'Leo';
+  if (value >= 823 && value <= 922) return 'Virgo';
+  if (value >= 923 && value <= 1022) return 'Libra';
+  if (value >= 1023 && value <= 1121) return 'Scorpio';
+  if (value >= 1122 && value <= 1221) return 'Sagittarius';
+  return 'Capricorn';
+}

--- a/web/src/app/api/numerology/route.ts
+++ b/web/src/app/api/numerology/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getLifePathNumber } from '@divination/astro-data/lib'
+import { getLifePathNumber } from '@divination/astro-data'
 
 export function GET(req: Request) {
   const { searchParams } = new URL(req.url)

--- a/web/src/app/api/zodiac/route.ts
+++ b/web/src/app/api/zodiac/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getZodiacSign } from '@divination/astro-data/lib'
+import { getZodiacSign } from '@divination/astro-data'
 
 export function GET(req: Request) {
   const { searchParams } = new URL(req.url)
@@ -7,7 +7,6 @@ export function GET(req: Request) {
   if (!date) {
     return NextResponse.json({ error: 'Missing date' }, { status: 400 })
   }
-  const [, month, day] = date.split('-').map(Number)
-  const sign = getZodiacSign(month, day)
+  const sign = getZodiacSign(date)
   return NextResponse.json({ sign })
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -20,9 +20,13 @@
     "types": [
       "@types/node"
     ],
+    "baseUrl": ".",
     "paths": {
       "@divination/astro-data": [
         "../packages/astro-data/lib"
+      ],
+      "@divination/astro-data/*": [
+        "../packages/astro-data/lib/*"
       ]
     },
     "incremental": true,


### PR DESCRIPTION
## Summary
- add `getZodiacSign` utility in astro-data package
- configure tsconfig paths
- use new util in API routes

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm -F web build` *(fails: next: not found)*
- `pnpm -F web next export` *(fails: no next script)*