### PR TITLE
Implement multi-card tarot API and i18n toggle

### DIFF
--- a/web/next-i18next.config.js
+++ b/web/next-i18next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next-i18next').UserConfig} */
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'ja'],
+  },
+};

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.27.0",
     "framer-motion": "^12.15.0",
+    "next-i18next": "^15.1.1",
+    "zustand": "^4.4.1",
     "next": "14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/web/src/app/api/tarot/route.ts
+++ b/web/src/app/api/tarot/route.ts
@@ -1,0 +1,20 @@
+export const runtime = 'edge'
+
+import { NextResponse } from 'next/server'
+import { tarotCards } from '@/data/tarot'
+
+export function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const cardsParam = searchParams.get('cards')
+  const count = cardsParam ? Number(cardsParam) : 1
+
+  const deck = [...tarotCards]
+  const results = []
+  for (let i = 0; i < Math.min(count, deck.length); i++) {
+    const idx = Math.floor(Math.random() * deck.length)
+    results.push(deck[idx])
+    deck.splice(idx, 1)
+  }
+
+  return NextResponse.json(count === 1 ? results[0] : results)
+}

--- a/web/src/app/components/TarotDrawer.tsx
+++ b/web/src/app/components/TarotDrawer.tsx
@@ -3,19 +3,21 @@
 import { motion } from 'framer-motion'
 import useSWR from 'swr'
 import { z } from 'zod'
+import { useLangStore } from '@/store/useLangStore'
 
 const TarotSchema = z.object({
   id: z.number(),
   name: z.string(),
   meaning: z.string(),
+  meaning_ja: z.string(),
 })
 
 export type Tarot = z.infer<typeof TarotSchema>
 
-const fetcher = async (url: string): Promise<Tarot> => {
+const fetcher = async (url: string): Promise<Tarot[]> => {
   const res = await fetch(url)
   const data = await res.json()
-  return TarotSchema.parse(data)
+  return z.array(TarotSchema).parse(data)
 }
 
 interface Props {
@@ -24,7 +26,8 @@ interface Props {
 }
 
 export default function TarotDrawer({ open, onClose }: Props) {
-  const { data } = useSWR(open ? '/api/tarot' : null, fetcher)
+  const { lang, toggle } = useLangStore()
+  const { data } = useSWR(open ? '/api/tarot?cards=3' : null, fetcher)
 
   return (
     <div
@@ -36,23 +39,40 @@ export default function TarotDrawer({ open, onClose }: Props) {
       >
         ×
       </button>
-      <div className="mt-8 p-4 text-center space-y-4">
+      <button
+        onClick={toggle}
+        className="absolute top-2 left-2 text-gray-500"
+      >
+        {lang === 'en' ? 'JA' : 'EN'}
+      </button>
+      <div className="mt-8 p-4 space-y-4">
         {data ? (
-          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
-            <img
-              src={`/tarot/${data.id}.svg`}
-              alt={data.name}
-              className="mx-auto w-48 h-auto"
-            />
-            <h2 className="mt-4 text-xl font-bold">{data.name}</h2>
-            <p className="mt-2 text-sm text-gray-700">{data.meaning}</p>
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="flex justify-center space-x-4">
+            {data.map(card => (
+              <div key={card.id} className="text-center">
+                <img
+                  src={`/tarot/${card.id}.svg`}
+                  alt={card.name}
+                  className="w-24 h-auto mx-auto"
+                />
+                <h2 className="mt-2 text-sm font-bold">{card.name}</h2>
+                <p className="mt-1 text-xs text-gray-700">
+                  {lang === 'en' ? card.meaning : card.meaning_ja}
+                </p>
+              </div>
+            ))}
           </motion.div>
         ) : (
-          <img
-            src="/tarot/back.svg"
-            alt="back"
-            className="mx-auto w-48 h-auto"
-          />
+          <div className="flex justify-center space-x-4">
+            {[0, 1, 2].map(i => (
+              <img
+                key={i}
+                src="/tarot/back.svg"
+                alt="back"
+                className="w-24 h-auto"
+              />
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/web/src/data/tarot.ts
+++ b/web/src/data/tarot.ts
@@ -1,0 +1,27 @@
+export interface TarotCard {
+  id: number;
+  name: string;
+  meaning: string;
+  meaning_ja: string;
+}
+
+export const tarotCards: TarotCard[] = [
+  {
+    id: 0,
+    name: 'The Fool',
+    meaning: 'Beginnings, innocence',
+    meaning_ja: '始まり、無邪気',
+  },
+  {
+    id: 1,
+    name: 'The Magician',
+    meaning: 'Willpower, creation',
+    meaning_ja: '意志、創造',
+  },
+  {
+    id: 2,
+    name: 'The High Priestess',
+    meaning: 'Intuition, secrets',
+    meaning_ja: '直感、秘密',
+  },
+];

--- a/web/src/store/useLangStore.ts
+++ b/web/src/store/useLangStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+type Lang = 'en' | 'ja'
+
+interface LangState {
+  lang: Lang
+  toggle: () => void
+}
+
+export const useLangStore = create<LangState>(set => ({
+  lang: 'en',
+  toggle: () => set(state => ({ lang: state.lang === 'en' ? 'ja' : 'en' })),
+}))

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -27,6 +27,9 @@
       ],
       "@divination/astro-data/*": [
         "../packages/astro-data/lib/*"
+      ],
+      "@/*": [
+        "src/*"
       ]
     },
     "incremental": true,


### PR DESCRIPTION
## Summary
- add tarot data set with English and Japanese meanings
- implement `/api/tarot` supporting variable number of cards
- enhance TarotDrawer for 3-card display and language toggle
- setup basic next-i18next config
- create Zustand store for language
- add next-i18next and zustand deps
- update tsconfig paths

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `pnpm lint` *(fails: next not found)*