### PR TITLE
Add OGP image generator API

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,8 @@
     "postcss": "^8.4.21",
     "prettier": "^3.1.0",
     "tailwindcss": "^3.3.3",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "@vercel/og": "latest",
+    "satori": "latest"
   }
 }

--- a/web/src/app/api/og/route.ts
+++ b/web/src/app/api/og/route.ts
@@ -1,0 +1,53 @@
+import { ImageResponse } from '@vercel/og'
+import tarot from '@/lib/tarotData'
+
+export const runtime = 'edge'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const ids = (searchParams.get('ids') ?? '')
+    .split(',')
+    .map(s => parseInt(s))
+    .filter(n => !Number.isNaN(n))
+    .slice(0, 3)
+
+  const cards = ids.length
+    ? ids.map(id => tarot[id])
+    : [tarot[Math.floor(Math.random() * tarot.length)]]
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '1080px',
+          height: '560px',
+          display: 'flex',
+          background: '#fff',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '32px',
+          fontFamily: 'Noto Sans JP',
+        }}
+      >
+        {cards.map(c => (
+          <div
+            key={c.id}
+            style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+          >
+            <img
+              src={c.image}
+              width={cards.length === 1 ? 360 : 250}
+              height={cards.length === 1 ? 600 : 400}
+              style={{ objectFit: 'cover', borderRadius: '12px' }}
+            />
+            <div style={{ marginTop: '16px', fontSize: '32px', fontWeight: 700 }}>
+              {c.nameJa}
+            </div>
+            <div style={{ fontSize: '24px', color: '#666' }}>{c.meaningJa}</div>
+          </div>
+        ))}
+      </div>
+    ),
+    { width: 1080, height: 560 }
+  )
+}

--- a/web/src/app/components/HeadTags.tsx
+++ b/web/src/app/components/HeadTags.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+
+interface Props {
+  ids?: number[]
+}
+
+export default function HeadTags({ ids }: Props) {
+  const query = ids && ids.length ? `?ids=${ids.join(',')}` : ''
+  const ogUrl = `/api/og${query}`
+
+  return (
+    <Head>
+      <meta property="og:image" content={ogUrl} />
+    </Head>
+  )
+}

--- a/web/src/lib/tarotData.ts
+++ b/web/src/lib/tarotData.ts
@@ -1,0 +1,29 @@
+export interface TarotInfo {
+  id: number
+  image: string
+  nameJa: string
+  meaningJa: string
+}
+
+export const tarot: TarotInfo[] = [
+  {
+    id: 0,
+    image: '/tarot/0.svg',
+    nameJa: '愚者',
+    meaningJa: '始まり、無邪気',
+  },
+  {
+    id: 1,
+    image: '/tarot/1.svg',
+    nameJa: '魔術師',
+    meaningJa: '意志、創造',
+  },
+  {
+    id: 2,
+    image: '/tarot/2.svg',
+    nameJa: '女教皇',
+    meaningJa: '直感、秘密',
+  },
+]
+
+export default tarot


### PR DESCRIPTION
## Summary
- add dev deps for `@vercel/og` and `satori`
- implement Edge API route `/api/og` returning tarot card OGP images
- store tarot card meta data with images
- create `HeadTags` component for dynamic og:image generation

## Testing
- `pnpm lint` *(fails: next not found)*