### PR TITLE
Switch to PNG card OGP images

### DIFF
--- a/web/src/app/api/og/route.tsx
+++ b/web/src/app/api/og/route.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime automatic */
 import { ImageResponse } from '@vercel/og'
-import tarot from '@/lib/tarotData'
+import tarot, { TarotCard } from '@/lib/tarotData'
 
 export const runtime = 'edge'
 
@@ -12,7 +12,7 @@ export async function GET(req: Request) {
     .filter(n => !Number.isNaN(n))
     .slice(0, 3)
 
-  const cards = ids.length
+  const cards: TarotCard[] = ids.length
     ? ids.map(id => tarot[id])
     : [tarot[Math.floor(Math.random() * tarot.length)]]
 

--- a/web/src/lib/tarotData.ts
+++ b/web/src/lib/tarotData.ts
@@ -1,140 +1,140 @@
-export interface TarotInfo {
+export interface TarotCard {
   id: number
   image: string
   nameJa: string
   meaningJa: string
 }
 
-export const tarot: TarotInfo[] = [
+export const tarot: TarotCard[] = [
   {
     id: 0,
-    image: '/tarot/0.png',
+    image: '/tarot_png/0.png',
     nameJa: '愚者',
     meaningJa: '始まり、無邪気',
   },
   {
     id: 1,
-    image: '/tarot/1.png',
+    image: '/tarot_png/1.png',
     nameJa: '魔術師',
     meaningJa: '意志、創造',
   },
   {
     id: 2,
-    image: '/tarot/2.png',
+    image: '/tarot_png/2.png',
     nameJa: '女教皇',
     meaningJa: '直感、秘密',
   },
   {
     id: 3,
-    image: '/tarot/3.png',
+    image: '/tarot_png/3.png',
     nameJa: '女帝',
     meaningJa: '豊かさ、養育',
   },
   {
     id: 4,
-    image: '/tarot/4.png',
+    image: '/tarot_png/4.png',
     nameJa: '皇帝',
     meaningJa: '安定、権威',
   },
   {
     id: 5,
-    image: '/tarot/5.png',
+    image: '/tarot_png/5.png',
     nameJa: '教皇',
     meaningJa: '伝統、信仰',
   },
   {
     id: 6,
-    image: '/tarot/6.png',
+    image: '/tarot_png/6.png',
     nameJa: '恋人',
     meaningJa: '選択、調和',
   },
   {
     id: 7,
-    image: '/tarot/7.png',
+    image: '/tarot_png/7.png',
     nameJa: '戦車',
     meaningJa: '勝利、決意',
   },
   {
     id: 8,
-    image: '/tarot/8.png',
+    image: '/tarot_png/8.png',
     nameJa: '力',
     meaningJa: '勇気、忍耐',
   },
   {
     id: 9,
-    image: '/tarot/9.png',
+    image: '/tarot_png/9.png',
     nameJa: '隠者',
     meaningJa: '内省、孤独',
   },
   {
     id: 10,
-    image: '/tarot/10.png',
+    image: '/tarot_png/10.png',
     nameJa: '運命の輪',
     meaningJa: '変化、運命',
   },
   {
     id: 11,
-    image: '/tarot/11.png',
+    image: '/tarot_png/11.png',
     nameJa: '正義',
     meaningJa: '公正、真実',
   },
   {
     id: 12,
-    image: '/tarot/12.png',
+    image: '/tarot_png/12.png',
     nameJa: '吊るされた男',
     meaningJa: '犠牲、視点転換',
   },
   {
     id: 13,
-    image: '/tarot/13.png',
+    image: '/tarot_png/13.png',
     nameJa: '死神',
     meaningJa: '終わり、変容',
   },
   {
     id: 14,
-    image: '/tarot/14.png',
+    image: '/tarot_png/14.png',
     nameJa: '節制',
     meaningJa: '調和、節度',
   },
   {
     id: 15,
-    image: '/tarot/15.png',
+    image: '/tarot_png/15.png',
     nameJa: '悪魔',
     meaningJa: '束縛、誘惑',
   },
   {
     id: 16,
-    image: '/tarot/16.png',
+    image: '/tarot_png/16.png',
     nameJa: '塔',
     meaningJa: '崩壊、啓示',
   },
   {
     id: 17,
-    image: '/tarot/17.png',
+    image: '/tarot_png/17.png',
     nameJa: '星',
     meaningJa: '希望、癒し',
   },
   {
     id: 18,
-    image: '/tarot/18.png',
+    image: '/tarot_png/18.png',
     nameJa: '月',
     meaningJa: '不安、幻想',
   },
   {
     id: 19,
-    image: '/tarot/19.png',
+    image: '/tarot_png/19.png',
     nameJa: '太陽',
     meaningJa: '喜び、成功',
   },
   {
     id: 20,
-    image: '/tarot/20.png',
+    image: '/tarot_png/20.png',
     nameJa: '審判',
     meaningJa: '復活、審判',
   },
   {
     id: 21,
-    image: '/tarot/21.png',
+    image: '/tarot_png/21.png',
     nameJa: '世界',
     meaningJa: '達成、統合',
   },


### PR DESCRIPTION
## Summary
- update tarot data to reference `/tarot_png` PNG assets
- export `TarotCard` type for safer usage
- import the type in OGP route

## Testing
- `pnpm -F web lint` *(fails: `next` not found)*
- `next build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430be8278883338c03e4792370bcbf