### PR TITLE
feat(shichihou): adopt full 7-year / 12-month algorithm & placeholder descriptions

### DIFF
--- a/web/src/app/api/shichihou/route.ts
+++ b/web/src/app/api/shichihou/route.ts
@@ -6,7 +6,10 @@ export const runtime = 'edge'
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const birth = url.searchParams.get('birth') ?? ''
+  const birth = url.searchParams.get('birth')
+  if (!birth) {
+    return NextResponse.json({ error: 'Missing birth' }, { status: 400 })
+  }
   const dateStr = url.searchParams.get('date') ?? undefined
   const base = dateStr ? new Date(dateStr) : new Date()
   const result = calcShichihou(birth, base)


### PR DESCRIPTION
## Summary
- port seven treasure calculations with 7‑year and 12‑month cycles
- expose STAR_DESCRIPTIONS with placeholder text for all 7 years
- require `birth` parameter in `/api/shichihou` route

## Testing
- `pnpm -F web lint`
- `pnpm -F web build`


------
https://chatgpt.com/codex/tasks/task_e_68492ecfe8348333a6cfd42bfb847be3