### PR TITLE
feat(profile): save shichihou star & display card

### DIFF
--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -1,0 +1,54 @@
+export const runtime = 'edge'
+
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export async function POST(req: Request) {
+  const { birth } = await req.json().catch(() => ({}))
+  if (!birth) {
+    return NextResponse.json({ error: 'Missing birth' }, { status: 400 })
+  }
+
+  const { origin } = new URL(req.url)
+  const calc = await fetch(`${origin}/api/shichihou?birth=${birth}`).then(res => res.json())
+
+  const token = req.headers.get('authorization')?.replace('Bearer ', '')
+  const { data: { user } } = await supabase.auth.getUser(token)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { error } = await supabase.from('profiles').upsert({
+    id: user.id,
+    birth,
+    shichihou_star: calc.star,
+    year_cycle: calc.yearCycle,
+  })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const uid = url.searchParams.get('uid')
+  if (!uid) {
+    return NextResponse.json({ error: 'Missing uid' }, { status: 400 })
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('birth, shichihou_star, year_cycle')
+    .eq('id', uid)
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json(data, {
+    headers: { 'Cache-Control': 'public, s-maxage=3600' },
+  })
+}

--- a/web/src/app/components/SevenTreasureCard.tsx
+++ b/web/src/app/components/SevenTreasureCard.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export default function SevenTreasureCard() {
+  const { data } = useSWR('/api/profile', fetcher)
+
+  if (!data) {
+    return <div className="w-40 h-24 bg-gray-200 animate-pulse rounded" />
+  }
+
+  return (
+    <div className="mt-4 p-4 border rounded text-center">
+      <p className="font-bold">{data.shichihou_star}</p>
+      <p className="text-sm text-gray-500">Year Cycle: {data.year_cycle}</p>
+    </div>
+  )
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import TarotDrawer from './components/TarotDrawer'
+import SevenTreasureCard from './components/SevenTreasureCard'
 
 export default function Home() {
   const [date, setDate] = useState('')
@@ -16,6 +17,11 @@ export default function Home() {
     setSign(zodiac.sign)
     const numerology = await fetch(`/api/numerology?date=${date}`).then(r => r.json())
     setPath(numerology.path)
+    await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ birth: date }),
+    })
   }
 
   return (
@@ -33,6 +39,7 @@ export default function Home() {
       </form>
       {sign && <p className="mt-4">星座: {sign}</p>}
       {path !== undefined && <p>ライフパス: {path}</p>}
+      <SevenTreasureCard />
       <button
         onClick={() => setOpen(true)}
         className="mt-8 px-4 py-2 bg-purple-500 text-white rounded"

--- a/web/src/lib/supabase.ts
+++ b/web/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+)


### PR DESCRIPTION
## Summary
- add supabase client under web/src/lib
- create /api/profile route to save and fetch profile data
- show SevenTreasureCard via SWR
- persist profile on birth submission

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68497201ef4c833392801096e1a5f77d